### PR TITLE
Try to just remove all recipients if possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>to.us.awesomest</groupId>
     <artifactId>ChatFree</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/to/us/awesomest/chatfree/ChatFree.java
+++ b/src/main/java/to/us/awesomest/chatfree/ChatFree.java
@@ -12,8 +12,15 @@ public class ChatFree extends JavaPlugin implements Listener {
     public void onEnable() {
         getServer().getPluginManager().registerEvents(this, this);
     }
+
     @EventHandler(priority = EventPriority.LOWEST)
     public void onChat(AsyncPlayerChatEvent event) {
-        event.setCancelled(true);
+        try {
+            // Try to remove all recipients
+            event.getRecipients().clear();
+        } catch(UnsupportedOperationException e) {
+            // If that fails cancel the event
+            event.setCancelled(true);
+        }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,5 @@
 name: ChatFree
-version: "1.0"
+version: "1.2"
 main: to.us.awesomest.chatfree.ChatFree
+api-version: "1.13"
 description: "A lightweight chat removal plugin"


### PR DESCRIPTION
If that fails fall back to just canceling the event.

Removing all recipients is the by far better method to prevent the chat being visible but still allowing plugins to see the chat messages so that they can process it.